### PR TITLE
Upload lawful-support fixes

### DIFF
--- a/Mods/10Release/10Farming/furniture.txt
+++ b/Mods/10Release/10Farming/furniture.txt
@@ -39,6 +39,7 @@
 	    Chance 0.1 Filter And { CreatureId "IMP" Not Indoors } DropItems {"sack"} 1
 	    Chance 0.1 Filter And { CreatureId "PESEANT_PLAYER" Not Indoors } DropItems {"sack"} 1
 	    Chance 0.1 Filter And { CreatureId "GOBLIN_WORKER" Not Indoors } DropItems {"sack"} 1
+		Chance 0.1 Filter And { CreatureId "ACOLYTE" Not Indoors } DropItems {"sack"} 1
 	  }
     usageTime = 20
     canBuildOutsideOfTerritory = true

--- a/Mods/10Release/10Farming/keeper_creatures.txt
+++ b/Mods/10Release/10Farming/keeper_creatures.txt
@@ -14,3 +14,18 @@
 	credit = { "CROPS" 25 }
 }
 
+"3_white_knight" modify {
+    immigrantGroups = append {"farm_animals" }
+	credit = { "CROPS" 25 }
+}
+
+"3_zchurch" modify {
+    immigrantGroups = append {"farm_animals" }
+	credit = { "CROPS" 25 }
+}
+
+"3_zmother" modify {
+    immigrantGroups = append {"farm_animals" }
+	credit = { "CROPS" 25 }
+}
+


### PR DESCRIPTION
Update files to issue lawful keepers the crop credit & include Acolytes (both genders) as eligible crop-producers.